### PR TITLE
rename eventbus package.

### DIFF
--- a/basic.go
+++ b/basic.go
@@ -1,4 +1,4 @@
-package event
+package eventbus
 
 import (
 	"errors"

--- a/basic_test.go
+++ b/basic_test.go
@@ -1,4 +1,4 @@
-package event
+package eventbus
 
 import (
 	"fmt"

--- a/opts.go
+++ b/opts.go
@@ -1,4 +1,4 @@
-package event
+package eventbus
 
 import (
 	"errors"


### PR DESCRIPTION
I'm integrating this component in libp2p and the `event` package name collides with `go-libp2p-core/event`. Since this repo only contains the event bus itself and nothing related to the event payloads, renaming this package seems appropriate.