### PR TITLE
Fix close deadlock (variant B)

### DIFF
--- a/basic_test.go
+++ b/basic_test.go
@@ -304,6 +304,28 @@ func TestStateful(t *testing.T) {
 	}
 }
 
+func TestCloseBlocking(t *testing.T) {
+	bus := NewBus()
+	em, err := bus.Emitter(new(EventB))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := make(chan EventB)
+	cancel, err := bus.Subscribe(events)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		em.Emit(EventB(159))
+	}()
+
+	time.Sleep(10 * time.Millisecond) // make sure that emit is blocked
+
+	cancel() // cancel sub
+}
+
 func testMany(t testing.TB, subs, emits, msgs int, stateful bool) {
 	if detectrace.WithRace() && subs+emits > 5000 {
 		t.SkipNow()


### PR DESCRIPTION
This fixes a deadlock when closing channels by draining the subscription channel in cancel func - assuming that usually we don't cancel a subscription and keep using the channel, this is fine.

There are other alternative approaches to this, but this one has the smallest perf hit (and doesn't allocate in `emit`).

Benchmarks vs master:
```
benchmark                       old ns/op     new ns/op     delta
BenchmarkSubs-32                540029        572087        +5.94%
BenchmarkEmits-32               1091485       866485        -20.61%
BenchmarkMsgs-32                962007        981052        +1.98%
BenchmarkOneToMany-32           80120         76505         -4.51%
BenchmarkManyToOne-32           126977        127218        +0.19%
BenchmarkMs1e2m4-32             2101          2028          -3.47%
BenchmarkMs1e0m6-32             416           450           +8.17%
BenchmarkMs0e0m6-32             218           220           +0.92%
BenchmarkStatefulMs1e0m6-32     415           473           +13.98%
BenchmarkStatefulMs0e0m6-32     284           300           +5.63%
BenchmarkMs0e6m0-32             4953          5074          +2.44%
BenchmarkMs6e0m0-32             4935          5101          +3.36%

benchmark                       old allocs     new allocs     delta
BenchmarkSubs-32                5              6              +20.00%
BenchmarkEmits-32               7              7              +0.00%
BenchmarkMsgs-32                0              0              +0.00%
BenchmarkOneToMany-32           5              5              +0.00%
BenchmarkManyToOne-32           6              6              +0.00%
BenchmarkMs1e2m4-32             0              0              +0.00%
BenchmarkMs1e0m6-32             0              0              +0.00%
BenchmarkMs0e0m6-32             0              0              +0.00%
BenchmarkStatefulMs1e0m6-32     0              0              +0.00%
BenchmarkStatefulMs0e0m6-32     1              1              +0.00%
BenchmarkMs0e6m0-32             7              7              +0.00%
BenchmarkMs6e0m0-32             6              6              +0.00%

benchmark                       old bytes     new bytes     delta
BenchmarkSubs-32                413           428           +3.63%
BenchmarkEmits-32               235           237           +0.85%
BenchmarkMsgs-32                20            21            +5.00%
BenchmarkOneToMany-32           432           432           +0.00%
BenchmarkManyToOne-32           168           165           -1.79%
BenchmarkMs1e2m4-32             0             0             +0.00%
BenchmarkMs1e0m6-32             0             0             +0.00%
BenchmarkMs0e0m6-32             0             0             +0.00%
BenchmarkStatefulMs1e0m6-32     3             3             +0.00%
BenchmarkStatefulMs0e0m6-32     32            32            +0.00%
BenchmarkMs0e6m0-32             576           574           -0.35%
BenchmarkMs6e0m0-32             498           499           +0.20%
```