### PR TITLE
Fix close deadlock and Sub type error

### DIFF
--- a/basic_test.go
+++ b/basic_test.go
@@ -318,6 +318,21 @@ func TestCloseBlocking(t *testing.T) {
 	sub.Close() // cancel sub
 }
 
+func TestSubFailFully(t *testing.T) {
+	bus := NewBus()
+	em, err := bus.Emitter(new(EventB))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = bus.Subscribe([]interface{}{new(EventB), 5})
+	if err == nil || err.Error() != "subscribe called with non-pointer type" {
+		t.Fatal(err)
+	}
+
+	em.Emit(EventB(159)) // will hang if sub doesn't fail properly
+}
+
 func testMany(t testing.TB, subs, emits, msgs int, stateful bool) {
 	if race.WithRace() && subs+emits > 5000 {
 		t.SkipNow()

--- a/basic_test.go
+++ b/basic_test.go
@@ -318,6 +318,11 @@ func TestCloseBlocking(t *testing.T) {
 	sub.Close() // cancel sub
 }
 
+func panicOnTimeout(d time.Duration) {
+	<-time.After(d)
+	panic("timeout reached")
+}
+
 func TestSubFailFully(t *testing.T) {
 	bus := NewBus()
 	em, err := bus.Emitter(new(EventB))
@@ -329,6 +334,8 @@ func TestSubFailFully(t *testing.T) {
 	if err == nil || err.Error() != "subscribe called with non-pointer type" {
 		t.Fatal(err)
 	}
+
+	go panicOnTimeout(5 * time.Second)
 
 	em.Emit(EventB(159)) // will hang if sub doesn't fail properly
 }

--- a/basic_test.go
+++ b/basic_test.go
@@ -297,6 +297,27 @@ func TestStateful(t *testing.T) {
 	}
 }
 
+func TestCloseBlocking(t *testing.T) {
+	bus := NewBus()
+	em, err := bus.Emitter(new(EventB))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sub, err := bus.Subscribe(new(EventB))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		em.Emit(EventB(159))
+	}()
+
+	time.Sleep(10 * time.Millisecond) // make sure that emit is blocked
+
+	sub.Close() // cancel sub
+}
+
 func testMany(t testing.TB, subs, emits, msgs int, stateful bool) {
 	if race.WithRace() && subs+emits > 5000 {
 		t.SkipNow()


### PR DESCRIPTION
Fixes libp2p/go-eventbus#10 and libp2p/go-libp2p#1704

Bench:
```
benchmark                       old ns/op     new ns/op     delta
BenchmarkSubs-32                498649        501377        +0.55%
BenchmarkEmits-32               962425        919298        -4.48%
BenchmarkMsgs-32                933676        990440        +6.08%
BenchmarkOneToMany-32           71033         70820         -0.30%
BenchmarkManyToOne-32           130073        131921        +1.42%
BenchmarkMs1e2m4-32             2078          2228          +7.22%
BenchmarkMs1e0m6-32             387           427           +10.34%
BenchmarkMs0e0m6-32             187           187           +0.00%
BenchmarkStatefulMs1e0m6-32     405           353           -12.84%
BenchmarkStatefulMs0e0m6-32     202           201           -0.50%
BenchmarkMs0e6m0-32             5355          4964          -7.30%
BenchmarkMs6e0m0-32             4241          6817          +60.74%

benchmark                       old allocs     new allocs     delta
BenchmarkSubs-32                8              10             +25.00%
BenchmarkEmits-32               7              7              +0.00%
BenchmarkMsgs-32                0              0              +0.00%
BenchmarkOneToMany-32           8              10             +25.00%
BenchmarkManyToOne-32           6              6              +0.00%
BenchmarkMs1e2m4-32             0              0              +0.00%
BenchmarkMs1e0m6-32             0              0              +0.00%
BenchmarkMs0e0m6-32             0              0              +0.00%
BenchmarkStatefulMs1e0m6-32     0              0              +0.00%
BenchmarkStatefulMs0e0m6-32     0              0              +0.00%
BenchmarkMs0e6m0-32             7              7              +0.00%
BenchmarkMs6e0m0-32             9              13             +44.44%

benchmark                       old bytes     new bytes     delta
BenchmarkSubs-32                355           520           +46.48%
BenchmarkEmits-32               254           256           +0.79%
BenchmarkMsgs-32                21            27            +28.57%
BenchmarkOneToMany-32           370           566           +52.97%
BenchmarkManyToOne-32           169           129           -23.67%
BenchmarkMs1e2m4-32             0             0             +0.00%
BenchmarkMs1e0m6-32             0             0             +0.00%
BenchmarkMs0e0m6-32             0             0             +0.00%
BenchmarkStatefulMs1e0m6-32     0             0             +0.00%
BenchmarkStatefulMs0e0m6-32     0             0             +0.00%
BenchmarkMs0e6m0-32             575           576           +0.17%
BenchmarkMs6e0m0-32             429           1142          +166.20%
```